### PR TITLE
[Fix]: Shader linker info log will now display correctly

### DIFF
--- a/libs/gl_utils/computeshader.cpp
+++ b/libs/gl_utils/computeshader.cpp
@@ -53,10 +53,16 @@ namespace gl
     if (!is_linked) {
         GLint max_length = 0;
         glGetProgramiv(shader_program, GL_INFO_LOG_LENGTH, &max_length);
-        std::vector<GLchar> info_log(max_length);
-        glGetProgramInfoLog(shader_program, max_length, &max_length, &info_log[0]);
-        std::string info_log_str(info_log.begin(), info_log.end());
-        std::cout << info_log_str << std::endl;
+
+		if (max_length != 0) {
+            std::vector<GLchar> info_log(max_length);
+            glGetProgramInfoLog(shader_program, max_length, &max_length, &info_log[0]);
+            std::string info_log_str(info_log.begin(), info_log.end());
+            std::cout << info_log_str << std::endl;
+        }
+        else {
+			std::cout << "No info log from linking compute shader program" << std::endl;
+        }
 
         fprintf(stderr, "Error in linking compute shader program\n");
         exit(41);

--- a/libs/gl_utils/computeshader.cpp
+++ b/libs/gl_utils/computeshader.cpp
@@ -46,21 +46,25 @@ namespace gl
     }
     
     glLinkProgram(shader_program);
-    glValidateProgram(shader_program);
+
+    // Check link status
+    int is_linked;
+    glGetProgramiv(shader_program, GL_LINK_STATUS, &is_linked);
+    if (!is_linked) {
+        GLint max_length = 0;
+        glGetProgramiv(shader_program, GL_INFO_LOG_LENGTH, &max_length);
+        std::vector<GLchar> info_log(max_length);
+        glGetProgramInfoLog(shader_program, max_length, &max_length, &info_log[0]);
+        std::string info_log_str(info_log.begin(), info_log.end());
+        std::cout << info_log_str << std::endl;
+
+        fprintf(stderr, "Error in linking compute shader program\n");
+        exit(41);
+    }
 
     gl::ExitOnGLError("gl::ComputeShader >> Unable to link shaders.");
 
-    // Check link status
-    int rvalue;
-    glGetProgramiv(shader_program, GL_LINK_STATUS, &rvalue);
-    if (!rvalue) {
-      fprintf(stderr, "Error in linking compute shader program\n");
-      GLchar log[10240];
-      GLsizei length;
-      glGetProgramInfoLog(shader_program, 10239, &length, log);
-      fprintf(stderr, "Linker log:\n%s\n", log);
-      exit(41);
-    }
+    glValidateProgram(shader_program);
 
     gl::ExitOnGLError("gl::ComputeShader >> Unable to load and link shaders.");
     


### PR DESCRIPTION
# Linker error std output

Instead of hard coding the size of the log:

```c++
// current
GLchar log[10240];
GLsizei length;
glGetProgramInfoLog(shader_program, 10239, &length, log);
```

we instead get the size from OpenGL:

```c++
// proposed new
GLint max_length = 0;
glGetProgramiv(shader_program, GL_INFO_LOG_LENGTH, &max_length);
std::vector<GLchar> info_log(max_length);
glGetProgramInfoLog(shader_program, max_length, &max_length, &info_log[0]);
```

This solves the issue where blank space would be printed instead of the actual info message. I encountered this issue when the log was quite long.

## Showcase

This example shows the linker log when trying to link my `nanorenderer.comp` shader.

#### New output
```
File Name TextFileRead "C:/Users/ander/Documents/volume_renderer/cppvolrend/openvdb/nanorenderer.comp"
Compute info
------------
0(3496) : warning C7050: "acc.key" might be used before being initialized
0(3496) : warning C7050: "acc.leaf.address.byte_offset" might be used before being initialized
0(3496) : warning C7050: "acc.lower.address.byte_offset" might be used before being initialized
0(3496) : warning C7050: "acc.upper.address.byte_offset" might be used before being initialized
0(3496) : warning C7050: "acc.root.address.byte_offset" might be used before being initialized
0(698) : error C5025: lvalue in array access too complex
0(698) : error C1068: ... or possible array index out of bounds

Error in linking compute shader program

C:\Users\anders\Documents\volume_renderer\bin\Debug\cppvolrend.exe (process 5704) exited with code 41 (0x29).
```

#### Old output
```
File Name TextFileRead "C:/Users/ander/Documents/volume_renderer/cppvolrend/openvdb/nanorenderer.comp"
Error in linking compute shader program
Linker log:


C:\Users\ander\Documents\volume_renderer\bin\Debug\cppvolrend.exe (process 7708) exited with code 41 (0x29).
```
</details>